### PR TITLE
fix: Remove Bearer from Authorization header

### DIFF
--- a/graphqlclient/client.py
+++ b/graphqlclient/client.py
@@ -19,7 +19,7 @@ class GraphQLClient:
                    'Content-Type': 'application/json'}
 
         if self.token is not None:
-            headers['Authorization'] = 'Bearer {}'.format(self.token)
+            headers['Authorization'] = '{}'.format(self.token)
 
         req = urllib.request.Request(self.endpoint, json.dumps(data).encode('utf-8'), headers)
 


### PR DESCRIPTION
User should be able to compose their own authorization header.
For example AWS API Gateway using Cognito User Pool can not check Authorization header token which has Bearer